### PR TITLE
Move rounding from API to client and render 2 decimal places

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,10 @@ Build a full-stack personal carbon footprint calculator:
 
 ## Development
 
-First, run `yarn` to install packages locally.
-
-Run `yarn dev` to run the development server and open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+### Getting started
+1. `nvm use` to set Node version based on `.nvmrc`
+1. `yarn` to install packages locally.
+1. Run `yarn dev` to run the development server and open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
 
 ### Commands
 - `yarn lint`

--- a/README.md
+++ b/README.md
@@ -32,12 +32,14 @@ Build a full-stack personal carbon footprint calculator:
   - `yarn test-client`
   - `yarn test-server`
 
-## Deployment
+### Workflows
+* `main` branch is protected - must contribute via Pull Request (PR)
+* CI checks (build lint and tests) are configured via GitHub workflow to run on PR and block merge if failing
 
+### Deployment
 This app is deployed using use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js. 
 - non-main branches are auto-built and deployed as preview sites. There can be up to 5 at once
 - main branch is auto-rebuilt and deployed to main site [`carbon-calculator-next-ts.vercel.app`](carbon-calculator-next-ts.vercel.app)
-
 
 Check out [Next.js deployment documentation](https://nextjs.org/docs/deployment) for more details.
 
@@ -55,17 +57,14 @@ The code is structured according to NextJS convention, with the `pages` folder i
 See [design doc](https://docs.google.com/document/d/1CXUhj5IibDofY0_00KOctsTjEd2b2JSCzZKFSt3eIKg/edit) for an in-depth breakdown.
 
 ### Lint configuration
-
 By default, the lint command (which uses `next lint` under the hood) only includes `components, lib, pages` folders. For simplicity, all code is organized within this limited structure.
 
 See `.eslintrc.json` for additional configuration.
 
 ### Test configuration
-
 Test coverage and jest options are defined under
 * `jest.client.config.js`
 * `jest.server.config.js`
 
 Test environment setup (run before tests) is defined under
 * `jest.client.setup.js`
-

--- a/components/Sidebar.test.tsx
+++ b/components/Sidebar.test.tsx
@@ -31,31 +31,10 @@ describe('Sidebar', () => {
     expect(screen.getByRole('button', { name: /reset/i }))
   })
 
-  it('renders nonzero emissions correctly', () => {
-    render(<Sidebar {...props} />)
-
-    const items = screen.getAllByRole('listitem')
-    expect(items).toHaveLength(allCalculationTypes.length)
-    items.forEach((item, index) => {
-      const { getByText } = within(item)
-      const calculationType = allCalculationTypes[index]
-      const expectedValue = props.calculations[calculationType]?.emissions.toString()
-      expect(expectedValue).not.toBeUndefined()
-      expect(getByText(calculationType + ':')).toBeInTheDocument()
-      expect(getByText(expectedValue as string)).toBeInTheDocument()
-    })
-  })
-
-  it('renders total emissions correctly', () => {
-    render(<Sidebar {...props} />)
-
-    expect(screen.getByRole('heading')).toHaveTextContent('Total: 300')
-  })
-
-  it('renders `Not yet calculated` if calculation is 0', () => {
+  it('renders undefined emissions as `Not yet calculated`', () => {
     props.calculations = {
-      food: { emissions: 0 },
-      transportation: { emissions: 0 }
+      food: undefined,
+      transportation: undefined
     }
 
     render(<Sidebar {...props} />)
@@ -70,15 +49,27 @@ describe('Sidebar', () => {
     })
   })
 
-  it('renders partial data correctly', () => {
+  it('renders zero emissions as zeros with 2 decimal places', () => {
     props.calculations = {
-      food: { emissions: 100 },
+      food: { emissions: 0 },
       transportation: { emissions: 0 }
     }
 
     render(<Sidebar {...props} />)
 
-    expect(screen.getByRole('heading')).toHaveTextContent('Total: 100')
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(allCalculationTypes.length)
+    items.forEach((item, index) => {
+      const { getByText } = within(item)
+      const calculationType = allCalculationTypes[index]
+      expect(getByText(calculationType + ':')).toBeInTheDocument()
+      const zero = 0
+      expect(getByText(zero.toFixed(2))).toBeInTheDocument()
+    })
+  })
+
+  it('renders nonzero emissions with 2 decimal places', () => {
+    render(<Sidebar {...props} />)
 
     const items = screen.getAllByRole('listitem')
     expect(items).toHaveLength(allCalculationTypes.length)
@@ -87,14 +78,40 @@ describe('Sidebar', () => {
       const calculationType = allCalculationTypes[index]
       const expectedValue = props.calculations[calculationType]?.emissions
       expect(expectedValue).not.toBeUndefined()
-      if (!expectedValue) {
-        expect(getByText('Not yet calculated')).toBeInTheDocument()
-      } else {
-        expect(getByText(expectedValue.toString())).toBeInTheDocument()
-      }
+      expect(getByText(calculationType + ':')).toBeInTheDocument()
+      expect(getByText((expectedValue as number).toFixed(2))).toBeInTheDocument()
     })
   })
 
+  it('renders total emissions correctly', () => {
+    render(<Sidebar {...props} />)
+
+    expect(screen.getByRole('heading')).toHaveTextContent('Total: 300.00')
+  })
+
+  it('renders partial data correctly', () => {
+    props.calculations = {
+      food: { emissions: 100 },
+      transportation: undefined
+    }
+
+    render(<Sidebar {...props} />)
+
+    expect(screen.getByRole('heading')).toHaveTextContent('Total: 100.00')
+
+    const items = screen.getAllByRole('listitem')
+    expect(items).toHaveLength(allCalculationTypes.length)
+    items.forEach((item, index) => {
+      const { getByText } = within(item)
+      const calculationType = allCalculationTypes[index]
+      const expectedValue = props.calculations[calculationType]?.emissions
+      if (!expectedValue) {
+        expect(getByText('Not yet calculated')).toBeInTheDocument()
+      } else {
+        expect(getByText(expectedValue.toFixed(2))).toBeInTheDocument()
+      }
+    })
+  })
 
   it('Reset button calls resetCalculation on click', async () => {
     render(<Sidebar {...props} />)

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -15,6 +15,12 @@ export const Sidebar: React.FC<ComponentProps> = ({ calculations, resetCalculati
     .map((ctype)=> calculations[ctype]?.emissions || 0)
     .reduce((prev, next) => prev+next, 0)
 
+  const renderEmissions = (emissions: number | undefined, decimalPlaces=2) => (
+    emissions !== undefined
+      ? emissions.toFixed(decimalPlaces)
+      : 'Not yet calculated'
+  )
+
   return <Sider
     width={SIDEBAR_WIDTH}
     style={{
@@ -33,11 +39,11 @@ export const Sidebar: React.FC<ComponentProps> = ({ calculations, resetCalculati
       <Card title='Emissions' size='default' extra={
         <Button onClick={ resetCalculations } type='ghost' >Reset</Button>
       }>
-        <Title level={2}>Total: { totalEmissions }</Title>
+        <Title level={2}>Total: { renderEmissions(totalEmissions) }</Title>
         { allCalculationTypes.map(ctype => (
           <li key={ctype}>
             <Text strong>{ctype}: </Text>
-            <Text>{calculations[ctype]?.emissions || 'Not yet calculated' }</Text>
+            <Text>{ renderEmissions(calculations[ctype]?.emissions) }</Text>
           </li>
         ))}
         <Divider />

--- a/lib/services/EmissionsCalculator.ts
+++ b/lib/services/EmissionsCalculator.ts
@@ -56,5 +56,3 @@ export const calculateTransportation = (data: Required<CalculateApi.RequestBody[
 
   return { emissions }
 }
-
-export const prettifyResult = (result: CalculationResult): CalculationResult => ({ emissions: Math.round(result.emissions) })

--- a/pages/api/calculate.ts
+++ b/pages/api/calculate.ts
@@ -1,6 +1,6 @@
 import type { NextApiHandler } from 'next'
 import { z } from 'zod'
-import { calculate, CalculationInput, CalculationResult, prettifyResult } from '../../lib/services/EmissionsCalculator'
+import { calculate, CalculationInput, CalculationResult } from '../../lib/services/EmissionsCalculator'
 import { withValidationHandled } from '../../lib/middlewares'
 
 // TODO: write server tests with nock
@@ -55,7 +55,7 @@ const handler: NextApiHandler<CalculateApi.ResponseBody> = (req, res) => {
         .map((calculationInput) => ({ ctype: calculationInput.ctype, result: calculate(calculationInput) }))
         // transform back to key-value form for output
         .reduce((acc, { ctype, result }) => {
-          acc[ctype] = prettifyResult(result)
+          acc[ctype] = result
           return acc
         }, {} as Partial<Record<CalculationType, CalculationResult>>)
 


### PR DESCRIPTION
## Functional changes
### Before
* numbers would not update for daily emissions < 0 (eg 500 cal vegetables)

### After
* numbers now show 2 decimal places, which is sufficient to show changes even for small inputs
* sidebar now distinguishes between 0 and undefined, rendering "0" instead of "Not yet calculated" for 0 values

https://user-images.githubusercontent.com/18102685/182530977-f1dc1e8e-7ad5-494f-9c52-7b4c1b6a80e1.mov

https://user-images.githubusercontent.com/18102685/182530969-149fe6ed-c263-4325-b481-c3801bc8b975.mov


## Discussion
### Rounding from API to client
This way, client defines how to present the data. Server can remain agnostic to presentation. 